### PR TITLE
chore: Allow lowercase character to start commit message

### DIFF
--- a/.github/workflows/semantic-commit.yml
+++ b/.github/workflows/semantic-commit.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Check Commit Message
         uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
         with:
-          pattern: '^(Merge .+|((feat|fix|chore|docs|style|refactor|perf|ci|test)(\(.+\))?: [A-Z0-9].+[^.\s])$)'
+          pattern: '^(Merge .+|((feat|fix|chore|docs|style|refactor|perf|ci|test)(\(.+\))?: [A-Za-z0-9].+[^.\s])$)'
           error: 'Commit messages and PR title should match conventional commit convention and start with an uppercase.'
           excludeDescription: 'true'
           excludeTitle: 'false'


### PR DESCRIPTION
Updated commit message pattern to allow lowercase letters.