### PR TITLE
fix(euria-review): Enable full context length use

### DIFF
--- a/.github/workflows/euria-review.yml
+++ b/.github/workflows/euria-review.yml
@@ -8,7 +8,6 @@ jobs:
     env:
       LLM__PROVIDER: "OPENROUTER"
       LLM__META__MODEL: "moonshotai/Kimi-K2.5"
-      LLM__META__MAX_TOKENS: "250000"
       LLM__META__TEMPERATURE: "0.3"
       LLM__HTTP_CLIENT__API_URL: "https://api.infomaniak.com/2/ai/27/openai/v1"
       LLM__HTTP_CLIENT__API_TOKEN: ${{ secrets.EURIA_API_KEY }}


### PR DESCRIPTION
A miss configuration breaks AI reviews with more than 6K context length.
After reviewing the code of the review library used, I chose to let Infomaniak AITools be the dynamic limit.
It will enforce the 256K context limit of kimik2.5 on its own.