### PR TITLE
ci: Skip workflows for fork pull requests in templates

### DIFF
--- a/workflow-templates/auto-author-assign.yml
+++ b/workflow-templates/auto-author-assign.yml
@@ -13,4 +13,5 @@ permissions:
 
 jobs:
   assign-author:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: infomaniak/.github/.github/workflows/auto_author_assign.yml@<hash>

--- a/workflow-templates/dependent-issues.yml
+++ b/workflow-templates/dependent-issues.yml
@@ -21,5 +21,6 @@ concurrency:
 
 jobs:
   check_dependencies:
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     uses: infomaniak/.github/.github/workflows/dependent-issues.yml@<hash>
     secrets: inherit


### PR DESCRIPTION
## Description

Add `if` conditions to workflow templates to skip jobs when the PR comes from a fork.

### Why

Following the fix applied across all mobile repos (replacing `pull_request_target` with `pull_request`), these templates need to be updated so any new repo bootstrapped from them includes the fork protection from the start.

- `auto-author-assign`: skipped entirely for fork PRs (write token unavailable)
- `dependent-issues`: skipped only for fork PRs — issues events still run normally

### Related PRs
All mobile repos have already been patched individually.